### PR TITLE
bean-discovery-mode="annotated" in cdi beans.xml

### DIFF
--- a/agent/performance/cdi/src/main/resources/META-INF/beans.xml
+++ b/agent/performance/cdi/src/main/resources/META-INF/beans.xml
@@ -19,7 +19,8 @@
 -->
 <beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-                            http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+                            http://java.sun.com/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
   <interceptors>
     <class>org.apache.sirona.cdi.SironaInterceptor</class>
   </interceptors>


### PR DESCRIPTION
from beans_1_1.xsd :

                   It is strongly recommended you use "annotated". 
                   
                   If the bean discovery mode is "all", then all types in this
                   archive will be considered. If the bean discovery mode is
                   "annotated", then only those types with bean defining annotations will be
                   considered. If the bean discovery mode is "none", then no
                   types will be considered.